### PR TITLE
Fix "typo" of "successfully" in commands

### DIFF
--- a/src/commands/deploy/aura.ts
+++ b/src/commands/deploy/aura.ts
@@ -110,7 +110,7 @@ export default class AuraDeploy extends SfdxCommand {
         auraDefinitions = auraDefinitions.length > 0 ? auraDefinitions : [];
         try {
           await upsertAuraDefinition(auraDefinitions, fileBodyArray, auraDefinitionBundles[0].Id);
-          this.ux.stopSpinner(chalk.bold.greenBright('AuraBundle Deployed SuccessFully ✔'));
+          this.ux.stopSpinner(chalk.bold.greenBright('AuraBundle Deployed Successfully ✔'));
         } catch (exception) {
           this.ux.stopSpinner(chalk.bold.redBright('Aura Component Save Failed ✖'));
           displaylog(exception, this.ux);

--- a/src/commands/deploy/lwc.ts
+++ b/src/commands/deploy/lwc.ts
@@ -123,7 +123,7 @@ export default class LWCDeploy extends SfdxCommand {
         lwcResources = lwcResources.length > 0 ? lwcResources : [];
         try {
           await upsertLWCDefinition(lwcResources, fileBodyArray, lwcBundles[0].Id);
-          this.ux.stopSpinner(chalk.bold.greenBright('Lighnting Web Components Deployed SuccessFully ✔'));
+          this.ux.stopSpinner(chalk.bold.greenBright('Lighnting Web Components Deployed Successfully ✔'));
           // console.log(auraDefinitionsResult);
         } catch (exception) {
           this.ux.stopSpinner(chalk.bold.redBright('Failed ✖'));

--- a/src/commands/deploy/staticresource.ts
+++ b/src/commands/deploy/staticresource.ts
@@ -126,7 +126,7 @@ export default class StaticResourceDeploy extends SfdxCommand {
         await conn.tooling.sobject("StaticResource").create(staticresource);
       }
       this.ux.stopSpinner(
-        chalk.bold.greenBright("StaticResource Deployed SuccessFully ✔")
+        chalk.bold.greenBright("StaticResource Deployed Successfully ✔")
       );
     } catch (e) {
       this.ux.stopSpinner(


### PR DESCRIPTION
Hey,

I enjoy how fast this plugin is compared to native sfdx deploys.

I noticed a "typo" (`SuccessFully` instead of `successfully`) in some of the commands and fixed it.

Cheers
KevSlashNull