### PR TITLE
feat(deploy:lwc): Metadata API fallback for Tooling schema-ref bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,14 +230,14 @@ EXAMPLES
 
 ---
 
-## Important Note
+## Important Notes
 
 ### Tracking changes against your org
 
 These commands do not maintain history. Files are overwritten on the server. Make sure you have source control set up for your project so you can recover code if needed.
 
 
-### Metadata Api Fallback
+### Metadata API Fallback
 
  When the Tooling API rejects a save because the bundle imports a custom field via `@salesforce/schema/` (a Tooling API Salesforce bug, see [#434](https://github.com/msrivastav13/mo-dx-plugin/issues/434)), `deploy:lwc`  automatically retries through the Metadata API. The save takes a few seconds longer and will surface success or errors from the Metadata API.
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,14 @@ EXAMPLES
 
 ## Important Note
 
+### Tracking changes against your org
+
 These commands do not maintain history. Files are overwritten on the server. Make sure you have source control set up for your project so you can recover code if needed.
+
+
+### Metadata Api Fallback
+
+ When the Tooling API rejects a save because the bundle imports a custom field via `@salesforce/schema/` (a Tooling API Salesforce bug, see [#434](https://github.com/msrivastav13/mo-dx-plugin/issues/434)), `deploy:lwc`  automatically retries through the Metadata API. The save takes a few seconds longer and will surface success or errors from the Metadata API.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,28 @@ See [CHANGELOG.md](./CHANGELOG.md) for full details. The key changes for existin
 
 ## Commands
 
-- [`sf deploy:apex`](#sf-deployapex)
-- [`sf deploy:trigger`](#sf-deploytrigger)
-- [`sf deploy:vf`](#sf-deployvf)
-- [`sf deploy:vfcomponent`](#sf-deployvfcomponent)
-- [`sf deploy:aura`](#sf-deployaura)
-- [`sf deploy:lwc`](#sf-deploylwc)
-- [`sf deploy:staticresource`](#sf-deploystaticresource)
-- [`sf retrieve:dxsource`](#sf-retrievedxsource)
-- [`sf retrieve:pkgsource`](#sf-retrievepkgsource)
-- [`sf metadata:rename`](#sf-metadatarename)
+- [mo-dx-plugin](#mo-dx-plugin)
+  - [Requirements](#requirements)
+  - [Installation](#installation)
+    - [Install as plugin (recommended)](#install-as-plugin-recommended)
+    - [Install from source](#install-from-source)
+  - [Upgrading from 0.x](#upgrading-from-0x)
+  - [Commands](#commands)
+    - [`sf deploy:apex`](#sf-deployapex)
+    - [`sf deploy:trigger`](#sf-deploytrigger)
+    - [`sf deploy:vf`](#sf-deployvf)
+    - [`sf deploy:vfcomponent`](#sf-deployvfcomponent)
+    - [`sf deploy:aura`](#sf-deployaura)
+    - [`sf deploy:lwc`](#sf-deploylwc)
+    - [`sf deploy:staticresource`](#sf-deploystaticresource)
+    - [`sf retrieve:dxsource`](#sf-retrievedxsource)
+    - [`sf retrieve:pkgsource`](#sf-retrievepkgsource)
+    - [`sf metadata:rename`](#sf-metadatarename)
+  - [Important Notes](#important-notes)
+    - [Tracking changes against your org](#tracking-changes-against-your-org)
+    - [Metadata API Fallback](#metadata-api-fallback)
+  - [Development](#development)
+  - [License](#license)
 
 ---
 
@@ -239,7 +251,7 @@ These commands do not maintain history. Files are overwritten on the server. Mak
 
 ### Metadata API Fallback
 
- When the Tooling API rejects a save because the bundle imports a custom field via `@salesforce/schema/` (a Tooling API Salesforce bug, see [#434](https://github.com/msrivastav13/mo-dx-plugin/issues/434)), `deploy:lwc`  automatically retries through the Metadata API. The save takes a few seconds longer and will surface success or errors from the Metadata API.
+ When the Tooling API rejects a save because the bundle imports a custom field via `@salesforce/schema/` (a Tooling API Salesforce bug, see [#434](https://github.com/msrivastav13/mo-dx-plugin/issues/434)), `deploy:lwc` automatically retries through the Metadata API. This applies whether you are creating a new bundle or updating an existing one. The save takes a few seconds longer and will surface success or errors from the Metadata API.
 
 ## Development
 

--- a/src/commands/deploy/lwc.ts
+++ b/src/commands/deploy/lwc.ts
@@ -6,7 +6,7 @@ import {SobjectResult} from '../../models/sObjectResult.js';
 import {displaylog} from '../../service/displayError.js';
 import {getNameSpacePrefix} from '../../service/getNamespacePrefix.js';
 import {readBundleFiles} from '../../service/readBundleFiles.js';
-import {isToolingSchemaRefBug, metadataFallbackDeploy} from '../../service/metadataDeployLwc.js';
+import {isToolingSchemaRefBug, metadataFallbackDeploy, FallbackOptions} from '../../service/metadataDeployLwc.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 
@@ -115,21 +115,62 @@ export default class LWCDeploy extends SfCommand<any> {
       this.spinner.stop(chalk.bold.greenBright(`Lighnting Web Components Deployed Successfully ✔.Command execution time: ${executionTime} seconds`));
     };
 
+    // Runs the Metadata API fallback and maps its outcome onto the spinner.
+    // Shared by the create and update schema-ref-bug paths.
+    const runMetadataFallback = async (options: FallbackOptions): Promise<void> => {
+      try {
+        const result = await metadataFallbackDeploy(options);
+        if (result.success) {
+          stopWithSuccess();
+        } else {
+          this.spinner.stop(chalk.bold.redBright('Failed ✖'));
+          displaylog(chalk.bold.redBright(result.message), this);
+        }
+      } catch (metaEx) {
+        this.spinner.stop(chalk.bold.redBright('Failed ✖'));
+        displaylog(chalk.bold.redBright(metaEx), this);
+      }
+    };
+
     try {
       let fileBodyArray = await getFileBodyMap(validFiles);
       let lwcBundles = [] as LightningComponentBundle[];
       lwcBundles = await getLWCDefinitionBundle(_fileOrDirName) as unknown as LightningComponentBundle[];
       if (lwcBundles.length === 0) {
-        const newLWCBundle = await createLWCBundle(_fileOrDirName, fileBodyArray) as unknown as SobjectResult;
-        if (newLWCBundle.success) {
-          const lwcBundleVar = {} as LightningComponentBundle;
-          lwcBundleVar.Id = newLWCBundle.id;
-          lwcBundles.push(lwcBundleVar);
-          // createLWCBundle may have expanded validFiles/filePath to the full directory;
-          // re-read so fileBodyArray stays in sync with validFiles.
-          fileBodyArray = await getFileBodyMap(validFiles);
-        } else {
-          displaylog(chalk.bold.redBright(JSON.stringify(newLWCBundle.errors)), this);
+        try {
+          const newLWCBundle = await createLWCBundle(_fileOrDirName, fileBodyArray) as unknown as SobjectResult;
+          if (newLWCBundle.success) {
+            const lwcBundleVar = {} as LightningComponentBundle;
+            lwcBundleVar.Id = newLWCBundle.id;
+            lwcBundles.push(lwcBundleVar);
+            // createLWCBundle may have expanded validFiles/filePath to the full directory;
+            // re-read so fileBodyArray stays in sync with validFiles.
+            fileBodyArray = await getFileBodyMap(validFiles);
+          } else {
+            displaylog(chalk.bold.redBright(JSON.stringify(newLWCBundle.errors)), this);
+          }
+        } catch (createException) {
+          if (isToolingSchemaRefBug(createException)) {
+            this.debug(`Tooling API rejected bundle creation with schema-ref bug — creating bundle "${_fileOrDirName}" via Metadata API`);
+            // createLWCBundle has already expanded to the full directory and filtered XML out
+            // of validFiles. Re-read the complete bundle from disk (including js-meta.xml, which
+            // the Metadata API requires) so the deploy creates a valid bundle. The Metadata API
+            // upserts, so a non-existent bundle is created rather than updated.
+            const bundleFiles = await readBundleFiles(_path);
+            await runMetadataFallback({
+              conn,
+              isDirectory: true,
+              validFiles: bundleFiles,
+              filePath: bundleFiles.map(file => getFilepath(_fileOrDirName, file)),
+              fileBodyArray: await getFileBodyMap(bundleFiles),
+              lwcBundleId: '',
+              bundleName: _fileOrDirName,
+              apiVersion,
+            });
+            // Bundle creation was handled via the Metadata API; skip the Tooling upsert below.
+            return '';
+          }
+          throw createException;
         }
       }
       if (lwcBundles.length > 0) {
@@ -142,27 +183,16 @@ export default class LWCDeploy extends SfCommand<any> {
         } catch (exception) {
           if (isToolingSchemaRefBug(exception)) {
             this.debug(`Tooling API rejected with schema-ref bug — retrying bundle "${_fileOrDirName}" via Metadata API`);
-            try {
-              const result = await metadataFallbackDeploy({
-                conn,
-                isDirectory,
-                validFiles,
-                filePath,
-                fileBodyArray,
-                lwcBundleId: lwcBundles[0].Id,
-                bundleName: _fileOrDirName,
-                apiVersion,
-              });
-              if (result.success) {
-                stopWithSuccess();
-              } else {
-                this.spinner.stop(chalk.bold.redBright('Failed ✖'));
-                displaylog(chalk.bold.redBright(result.message), this);
-              }
-            } catch (metaEx) {
-              this.spinner.stop(chalk.bold.redBright('Failed ✖'));
-              displaylog(chalk.bold.redBright(metaEx), this);
-            }
+            await runMetadataFallback({
+              conn,
+              isDirectory,
+              validFiles,
+              filePath,
+              fileBodyArray,
+              lwcBundleId: lwcBundles[0].Id,
+              bundleName: _fileOrDirName,
+              apiVersion,
+            });
           } else {
             this.spinner.stop(chalk.bold.redBright('Failed ✖'));
             displaylog(chalk.bold.redBright(exception), this);
@@ -199,7 +229,11 @@ export default class LWCDeploy extends SfCommand<any> {
         _fileOrDirName = _path.substring(_path.lastIndexOf('/') + 1);
         filePath = validFiles.map( file => getFilepath(_fileOrDirName, file));
       }
-      // Filter all the xml files as those are not supported yet
+      // Filter all the xml files as those are not supported yet.
+      // Note: this drops <bundle>.js-meta.xml from validFiles, so a Metadata API
+      // fallback triggered on this create-then-upsert path would be missing the
+      // meta file. metadataFallbackDeploy guards against that and asks the user
+      // to re-run against the full bundle directory.
       validFiles = validFiles.filter( file => {
         if (file.substring(file.lastIndexOf('.') + 1) !== 'xml') {
           return file;

--- a/src/commands/deploy/lwc.ts
+++ b/src/commands/deploy/lwc.ts
@@ -6,6 +6,7 @@ import {SobjectResult} from '../../models/sObjectResult.js';
 import {displaylog} from '../../service/displayError.js';
 import {getNameSpacePrefix} from '../../service/getNamespacePrefix.js';
 import {readBundleFiles} from '../../service/readBundleFiles.js';
+import {isToolingSchemaRefBug, metadataFallbackDeploy} from '../../service/metadataDeployLwc.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 
@@ -108,8 +109,14 @@ export default class LWCDeploy extends SfCommand<any> {
       filePath.push(getFilepath( _fileOrDirName, fileNameWithPath));
     }
 
+    const stopWithSuccess = () => {
+      this.endTime = new Date().getTime();
+      const executionTime = (this.endTime - this.startTime) / 1000;
+      this.spinner.stop(chalk.bold.greenBright(`Lighnting Web Components Deployed Successfully ✔.Command execution time: ${executionTime} seconds`));
+    };
+
     try {
-      const fileBodyArray = await getFileBodyMap(validFiles);
+      let fileBodyArray = await getFileBodyMap(validFiles);
       let lwcBundles = [] as LightningComponentBundle[];
       lwcBundles = await getLWCDefinitionBundle(_fileOrDirName) as unknown as LightningComponentBundle[];
       if (lwcBundles.length === 0) {
@@ -118,6 +125,9 @@ export default class LWCDeploy extends SfCommand<any> {
           const lwcBundleVar = {} as LightningComponentBundle;
           lwcBundleVar.Id = newLWCBundle.id;
           lwcBundles.push(lwcBundleVar);
+          // createLWCBundle may have expanded validFiles/filePath to the full directory;
+          // re-read so fileBodyArray stays in sync with validFiles.
+          fileBodyArray = await getFileBodyMap(validFiles);
         } else {
           displaylog(chalk.bold.redBright(JSON.stringify(newLWCBundle.errors)), this);
         }
@@ -127,13 +137,36 @@ export default class LWCDeploy extends SfCommand<any> {
         lwcResources = lwcResources.length > 0 ? lwcResources : [];
         try {
           await upsertLWCDefinition(lwcResources, fileBodyArray, lwcBundles[0].Id);
-          this.endTime = new Date().getTime();
-          const executionTime = (this.endTime - this.startTime) / 1000;
-          this.spinner.stop(chalk.bold.greenBright(`Lighnting Web Components Deployed Successfully ✔.Command execution time: ${executionTime} seconds`));
+          stopWithSuccess();
           // console.log(auraDefinitionsResult);
         } catch (exception) {
-          this.spinner.stop(chalk.bold.redBright('Failed ✖'));
-          displaylog(chalk.bold.redBright(exception), this);
+          if (isToolingSchemaRefBug(exception)) {
+            this.debug(`Tooling API rejected with schema-ref bug — retrying bundle "${_fileOrDirName}" via Metadata API`);
+            try {
+              const result = await metadataFallbackDeploy({
+                conn,
+                isDirectory,
+                validFiles,
+                filePath,
+                fileBodyArray,
+                lwcBundleId: lwcBundles[0].Id,
+                bundleName: _fileOrDirName,
+                apiVersion,
+              });
+              if (result.success) {
+                stopWithSuccess();
+              } else {
+                this.spinner.stop(chalk.bold.redBright('Failed ✖'));
+                displaylog(chalk.bold.redBright(result.message), this);
+              }
+            } catch (metaEx) {
+              this.spinner.stop(chalk.bold.redBright('Failed ✖'));
+              displaylog(chalk.bold.redBright(metaEx), this);
+            }
+          } else {
+            this.spinner.stop(chalk.bold.redBright('Failed ✖'));
+            displaylog(chalk.bold.redBright(exception), this);
+          }
         }
       }
     } catch (exception) {

--- a/src/service/metadataDeployLwc.ts
+++ b/src/service/metadataDeployLwc.ts
@@ -1,0 +1,120 @@
+import AdmZip from 'adm-zip';
+import { PackageXmlTemplate } from './packagexmlbuilder/packagexmlTemplate.js';
+import { delay } from './delay.js';
+
+export const METADATA_DEPLOY_TIMEOUT_MS = 120_000;
+export const METADATA_DEPLOY_POLL_INTERVAL_MS = 3_000;
+
+export function isToolingSchemaRefBug(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    msg.includes('FIELD_INTEGRITY_EXCEPTION') ||
+    /Invalid reference .+ of type sobjectField/.test(msg) ||
+    (err != null && typeof (err as any).errorCode === 'string' && (err as any).errorCode === 'FIELD_INTEGRITY_EXCEPTION')
+  );
+}
+
+export function buildLwcPackageXml(bundleName: string, version: string): string {
+  return (
+    PackageXmlTemplate.createHeader() +
+    PackageXmlTemplate.startType() +
+    PackageXmlTemplate.createMember(bundleName) +
+    PackageXmlTemplate.nameTag('LightningComponentBundle') +
+    PackageXmlTemplate.endType() +
+    PackageXmlTemplate.createFooter(version)
+  );
+}
+
+export interface FallbackOptions {
+  conn: any;
+  isDirectory: boolean;
+  validFiles: string[];
+  filePath: string[];
+  fileBodyArray: string[];
+  lwcBundleId: string;
+  bundleName: string;
+  apiVersion: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export interface FallbackResult {
+  success: boolean;
+  message: string;
+  timedOut?: boolean;
+}
+
+export async function metadataFallbackDeploy(options: FallbackOptions): Promise<FallbackResult> {
+  const {
+    conn,
+    isDirectory,
+    validFiles,
+    filePath,
+    fileBodyArray,
+    lwcBundleId,
+    bundleName,
+    apiVersion,
+    timeoutMs = METADATA_DEPLOY_TIMEOUT_MS,
+    pollIntervalMs = METADATA_DEPLOY_POLL_INTERVAL_MS,
+  } = options;
+
+  const fileMap = new Map<string, string>();
+
+  if (isDirectory) {
+    for (let i = 0; i < validFiles.length; i++) {
+      fileMap.set(filePath[i], fileBodyArray[i]);
+    }
+  } else {
+    const orgResources = await conn.tooling
+      .sobject('LightningComponentResource')
+      .find({ LightningComponentBundleId: lwcBundleId }, ['FilePath', 'Source']) as Array<{ FilePath: string; Source: string }>;
+    for (const r of orgResources) {
+      fileMap.set(r.FilePath, r.Source);
+    }
+    fileMap.set(filePath[0], fileBodyArray[0]);
+  }
+
+  const zip = new AdmZip();
+  for (const [fp, source] of fileMap.entries()) {
+    if (!fp.startsWith('lwc/') || fp.includes('..')) {
+      throw new Error(`Unsafe file path in bundle: ${fp}`);
+    }
+    zip.addFile(fp, Buffer.from(source, 'utf8'));
+  }
+  zip.addFile('package.xml', Buffer.from(buildLwcPackageXml(bundleName, apiVersion), 'utf8'));
+  const zipBuffer = zip.toBuffer();
+
+  const asyncResult = await conn.metadata.deploy(zipBuffer, { singlePackage: true, rollbackOnError: true }) as any;
+  const jobId = asyncResult.id;
+
+  let status: any;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    status = await conn.metadata.checkDeployStatus(jobId, true);
+    if (['Succeeded', 'Failed', 'Canceled'].includes(status.status)) break;
+    await delay(pollIntervalMs);
+  }
+
+  if (!status || !['Succeeded', 'Failed', 'Canceled'].includes(status.status)) {
+    return {
+      success: false,
+      // The job may still be running server-side; avoid re-deploying without checking org state.
+      message: `Metadata API deploy did not complete within ${timeoutMs / 1000}s — it may still be in progress on the server. Re-check org state before re-deploying.`,
+      timedOut: true,
+    };
+  }
+
+  if (status.success) {
+    return { success: true, message: '' };
+  }
+
+  const failures = status.details?.componentFailures ?? [];
+  const failList = Array.isArray(failures) ? failures : [failures];
+  let msg = failList.map((f: any) => `${f.fileName}: ${f.problem}`).join('\n');
+  if (!msg) msg = 'Metadata API deploy failed';
+  if (isDirectory) {
+    msg += '\nNote: The Tooling API may have partially updated some bundle resources before the error. Re-deploying the full bundle is recommended.';
+  }
+
+  return { success: false, message: msg };
+}

--- a/src/service/metadataDeployLwc.ts
+++ b/src/service/metadataDeployLwc.ts
@@ -69,16 +69,37 @@ export async function metadataFallbackDeploy(options: FallbackOptions): Promise<
       .sobject('LightningComponentResource')
       .find({ LightningComponentBundleId: lwcBundleId }, ['FilePath', 'Source']) as Array<{ FilePath: string; Source: string }>;
     for (const r of orgResources) {
-      fileMap.set(r.FilePath, r.Source);
+      // Source can come back null for some resource rows; coalesce so the zip
+      // step below fails (if at all) with a Metadata API error rather than a
+      // raw Buffer.from(null) TypeError.
+      fileMap.set(r.FilePath, r.Source ?? '');
     }
     fileMap.set(filePath[0], fileBodyArray[0]);
   }
 
-  const zip = new AdmZip();
-  for (const [fp, source] of fileMap.entries()) {
+  // Validate every resource path before anything else — security first.
+  for (const fp of fileMap.keys()) {
     if (!fp.startsWith('lwc/') || fp.includes('..')) {
       throw new Error(`Unsafe file path in bundle: ${fp}`);
     }
+  }
+
+  // A LightningComponentBundle Metadata deploy is invalid without its
+  // js-meta.xml. It is reliably absent only on the create-then-fallback path,
+  // where createLWCBundle filters all *.xml out of validFiles before the
+  // failing Tooling upsert. Bail here with an actionable message rather than
+  // building an incomplete (and possibly index-misaligned) zip that the
+  // Metadata API would reject with a confusing secondary error.
+  const metaXmlKey = `lwc/${bundleName}/${bundleName}.js-meta.xml`;
+  if (!fileMap.has(metaXmlKey)) {
+    return {
+      success: false,
+      message: `Could not assemble a complete bundle for the Metadata API fallback (missing ${bundleName}.js-meta.xml). This can happen when a new bundle is created from a single file. Please re-run the deploy against the full bundle directory.`,
+    };
+  }
+
+  const zip = new AdmZip();
+  for (const [fp, source] of fileMap.entries()) {
     zip.addFile(fp, Buffer.from(source, 'utf8'));
   }
   zip.addFile('package.xml', Buffer.from(buildLwcPackageXml(bundleName, apiVersion), 'utf8'));

--- a/test/commands/deploy/lwc.test.ts
+++ b/test/commands/deploy/lwc.test.ts
@@ -1,0 +1,297 @@
+import AdmZip from 'adm-zip';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  isToolingSchemaRefBug,
+  buildLwcPackageXml,
+  metadataFallbackDeploy,
+} from '../../../src/service/metadataDeployLwc.js';
+
+describe('isToolingSchemaRefBug', () => {
+  it('returns false for a genuine compile error (LWC1099)', () => {
+    expect(isToolingSchemaRefBug(new Error('LWC1099: Unknown prop "foo"'))).to.be.false;
+  });
+
+  it('returns true when errorCode is FIELD_INTEGRITY_EXCEPTION', () => {
+    const err = Object.assign(new Error('some message'), { errorCode: 'FIELD_INTEGRITY_EXCEPTION' });
+    expect(isToolingSchemaRefBug(err)).to.be.true;
+  });
+
+  it('returns true when message contains FIELD_INTEGRITY_EXCEPTION', () => {
+    expect(isToolingSchemaRefBug(new Error('FIELD_INTEGRITY_EXCEPTION: bad reference'))).to.be.true;
+  });
+
+  it('returns true when message matches Invalid reference … of type sobjectField pattern', () => {
+    expect(
+      isToolingSchemaRefBug(new Error('Invalid reference CustomObject__c.CustomField__c of type sobjectField in file ccdxSample.js: Source'))
+    ).to.be.true;
+  });
+
+  it('returns false for unrelated non-Error values', () => {
+    expect(isToolingSchemaRefBug('Something went wrong')).to.be.false;
+    expect(isToolingSchemaRefBug(null)).to.be.false;
+  });
+});
+
+describe('buildLwcPackageXml', () => {
+  it('generates well-formed package.xml with LightningComponentBundle member', () => {
+    const xml = buildLwcPackageXml('myBundle', '60.0');
+    expect(xml).to.include('<members>myBundle</members>');
+    expect(xml).to.include('<name>LightningComponentBundle</name>');
+    expect(xml).to.include('<version>60.0</version>');
+    expect(xml).to.include('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).to.include('<Package xmlns="http://soap.sforce.com/2006/04/metadata">');
+  });
+});
+
+describe('metadataFallbackDeploy', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function buildConn({
+    deployResult = { id: 'deployId001', done: false } as any,
+    checkStatusResult = { status: 'Succeeded', success: true, details: { componentFailures: [] } } as any,
+    findResult = [] as Array<{ FilePath: string; Source: string }>,
+  } = {}) {
+    const findStub = sandbox.stub().resolves(findResult);
+    const sobjectStub = sandbox.stub().returns({ find: findStub });
+    const deployStub = sandbox.stub().resolves(deployResult);
+    const checkDeployStatusStub = sandbox.stub().resolves(checkStatusResult);
+    return {
+      conn: {
+        tooling: { sobject: sobjectStub },
+        metadata: { deploy: deployStub, checkDeployStatus: checkDeployStatusStub },
+      } as any,
+      deployStub,
+      checkDeployStatusStub,
+      findStub,
+      sobjectStub,
+    };
+  }
+
+  it('test 4 — directory path: fallback succeeds, zip contains all bundle files and valid package.xml', async () => {
+    const { conn, deployStub, checkDeployStatusStub } = buildConn();
+
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: true,
+      validFiles: ['ccdxSample.js', 'ccdxSample.html', 'ccdxSample.js-meta.xml'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js', 'lwc/ccdxSample/ccdxSample.html', 'lwc/ccdxSample/ccdxSample.js-meta.xml'],
+      fileBodyArray: ['js content', '<template></template>', '<LightningComponentBundle/>'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.true;
+
+    // Verify zip contents
+    const [zipBuffer] = deployStub.firstCall.args;
+    const zip = new AdmZip(zipBuffer);
+    const entries = zip.getEntries().map(e => e.entryName);
+    expect(entries).to.include('lwc/ccdxSample/ccdxSample.js');
+    expect(entries).to.include('lwc/ccdxSample/ccdxSample.html');
+    expect(entries).to.include('lwc/ccdxSample/ccdxSample.js-meta.xml');
+    expect(entries).to.include('package.xml');
+
+    const pkgXmlEntry = zip.getEntry('package.xml');
+    const pkgXml = pkgXmlEntry.getData().toString('utf8');
+    expect(pkgXml).to.include('<members>ccdxSample</members>');
+    expect(pkgXml).to.include('<name>LightningComponentBundle</name>');
+    expect(pkgXml).to.include('<version>60.0</version>');
+
+    const [, deployOptions] = deployStub.firstCall.args;
+    expect(deployOptions).to.deep.include({ singlePackage: true, rollbackOnError: true });
+
+    sinon.assert.calledWith(checkDeployStatusStub, 'deployId001', true);
+  });
+
+  it('test 5 — single file: fetches org resources and overlays changed file', async () => {
+    const orgResources = [
+      { FilePath: 'lwc/ccdxSample/ccdxSample.js', Source: 'original js' },
+      { FilePath: 'lwc/ccdxSample/ccdxSample.html', Source: '<template/>' },
+      { FilePath: 'lwc/ccdxSample/ccdxSample.js-meta.xml', Source: '<LightningComponentBundle/>' },
+    ];
+    const { conn, deployStub, findStub } = buildConn({ findResult: orgResources });
+
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: false,
+      validFiles: ['ccdxSample.js'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js'],
+      fileBodyArray: ['updated js content'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.true;
+
+    sinon.assert.calledWith(findStub, { LightningComponentBundleId: 'bundleId001' }, ['FilePath', 'Source']);
+
+    const [zipBuffer] = deployStub.firstCall.args;
+    const zip = new AdmZip(zipBuffer);
+    const jsEntry = zip.getEntry('lwc/ccdxSample/ccdxSample.js');
+    expect(jsEntry.getData().toString('utf8')).to.equal('updated js content');
+    const htmlEntry = zip.getEntry('lwc/ccdxSample/ccdxSample.html');
+    expect(htmlEntry.getData().toString('utf8')).to.equal('<template/>');
+  });
+
+  it('test 6 — both fail: returns Metadata failure message (not original Tooling message)', async () => {
+    const { conn } = buildConn({
+      checkStatusResult: {
+        status: 'Failed',
+        success: false,
+        details: {
+          componentFailures: [{ fileName: 'lwc/ccdxSample/ccdxSample.js', problem: 'Compile error' }],
+        },
+      },
+    });
+
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: true,
+      validFiles: ['ccdxSample.js', 'ccdxSample.js-meta.xml'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js', 'lwc/ccdxSample/ccdxSample.js-meta.xml'],
+      fileBodyArray: ['bad content', '<LightningComponentBundle/>'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.false;
+    expect(result.message).to.include('lwc/ccdxSample/ccdxSample.js: Compile error');
+    expect(result.message).to.include('Tooling API may have partially updated');
+  });
+
+  it('test 6b — single-file failure has no partial-success note', async () => {
+    const { conn } = buildConn({
+      checkStatusResult: {
+        status: 'Failed',
+        success: false,
+        details: {
+          componentFailures: { fileName: 'lwc/ccdxSample/ccdxSample.js', problem: 'Error' },
+        },
+      },
+      findResult: [
+        { FilePath: 'lwc/ccdxSample/ccdxSample.js', Source: 'content' },
+        { FilePath: 'lwc/ccdxSample/ccdxSample.js-meta.xml', Source: '<LightningComponentBundle/>' },
+      ],
+    });
+
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: false,
+      validFiles: ['ccdxSample.js'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js'],
+      fileBodyArray: ['updated content'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.false;
+    expect(result.message).to.not.include('Tooling API may have partially updated');
+  });
+
+  it('test 7 — timeout: returns timed-out failure when deploy never completes', async () => {
+    const checkStatusStub = sandbox.stub().resolves({ status: 'InProgress', success: false });
+    const conn = {
+      tooling: { sobject: sandbox.stub().returns({ find: sandbox.stub() }) },
+      metadata: {
+        deploy: sandbox.stub().resolves({ id: 'deployId001' }),
+        checkDeployStatus: checkStatusStub,
+      },
+    } as any;
+
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: true,
+      validFiles: ['ccdxSample.js', 'ccdxSample.js-meta.xml'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js', 'lwc/ccdxSample/ccdxSample.js-meta.xml'],
+      fileBodyArray: ['content', '<LightningComponentBundle/>'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 0,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.false;
+    expect(result.timedOut).to.be.true;
+    expect(result.message).to.include('did not complete within 0s');
+    expect(result.message).to.include('may still be in progress');
+    sinon.assert.notCalled(checkStatusStub);
+  });
+
+  it('test 8 — path safety: throws on FilePath containing ".."', async () => {
+    const orgResources = [
+      { FilePath: 'lwc/../../../etc/passwd', Source: 'evil' },
+    ];
+    const { conn } = buildConn({ findResult: orgResources });
+
+    try {
+      await metadataFallbackDeploy({
+        conn,
+        isDirectory: false,
+        validFiles: ['ccdxSample.js'],
+        filePath: ['lwc/ccdxSample/ccdxSample.js'],
+        fileBodyArray: ['content'],
+        lwcBundleId: 'bundleId001',
+        bundleName: 'ccdxSample',
+        apiVersion: '60.0',
+        timeoutMs: 5_000,
+        pollIntervalMs: 0,
+      });
+      expect.fail('Expected an error to be thrown');
+    } catch (err: any) {
+      expect(err.message).to.include('Unsafe file path in bundle');
+    }
+  });
+
+  it('test 8b — path safety: throws on FilePath not starting with "lwc/"', async () => {
+    const orgResources = [
+      { FilePath: '/etc/passwd', Source: 'evil' },
+    ];
+    const { conn } = buildConn({ findResult: orgResources });
+
+    try {
+      await metadataFallbackDeploy({
+        conn,
+        isDirectory: false,
+        validFiles: ['ccdxSample.js'],
+        filePath: ['lwc/ccdxSample/ccdxSample.js'],
+        fileBodyArray: ['content'],
+        lwcBundleId: 'bundleId001',
+        bundleName: 'ccdxSample',
+        apiVersion: '60.0',
+        timeoutMs: 5_000,
+        pollIntervalMs: 0,
+      });
+      expect.fail('Expected an error to be thrown');
+    } catch (err: any) {
+      expect(err.message).to.include('Unsafe file path in bundle');
+    }
+  });
+
+  it('test 9 — regression guard: metadata.deploy is never called when isToolingSchemaRefBug returns false', () => {
+    expect(isToolingSchemaRefBug(new Error('LWC1099: Unknown property "foo"'))).to.be.false;
+    expect(isToolingSchemaRefBug(new Error('NetworkError: timeout'))).to.be.false;
+    expect(isToolingSchemaRefBug(null)).to.be.false;
+  });
+});

--- a/test/commands/deploy/lwc.test.ts
+++ b/test/commands/deploy/lwc.test.ts
@@ -27,6 +27,26 @@ describe('isToolingSchemaRefBug', () => {
     ).to.be.true;
   });
 
+  // Observed against a real org (API 66): the jsforce path surfaces the schema-ref bug
+  // as AURA_COMPILE_ERROR, NOT FIELD_INTEGRITY_EXCEPTION (which is the raw-REST form). The
+  // message regex — not the errorCode — is what distinguishes it.
+  it('returns true for the real AURA_COMPILE_ERROR schema-ref bug shape', () => {
+    const err = Object.assign(
+      new Error('Invalid reference CustomObject__c.CustomField__c of type sobjectField in file ccdxSample.js'),
+      { errorCode: 'AURA_COMPILE_ERROR', name: 'AURA_COMPILE_ERROR' }
+    );
+    expect(isToolingSchemaRefBug(err)).to.be.true;
+  });
+
+  // Same errorCode as the bug, but a genuine compile error — must NOT trigger the fallback.
+  it('returns false for a genuine AURA_COMPILE_ERROR parse error (LWC1503)', () => {
+    const err = Object.assign(
+      new Error('ccdxSample.js [Line: 5, Col: 2] (markup://c:ccdxSample) -- LWC1503: Parsing error: Missing semicolon. (5:2)'),
+      { errorCode: 'AURA_COMPILE_ERROR', name: 'AURA_COMPILE_ERROR' }
+    );
+    expect(isToolingSchemaRefBug(err)).to.be.false;
+  });
+
   it('returns false for unrelated non-Error values', () => {
     expect(isToolingSchemaRefBug('Something went wrong')).to.be.false;
     expect(isToolingSchemaRefBug(null)).to.be.false;
@@ -115,6 +135,58 @@ describe('metadataFallbackDeploy', () => {
     sinon.assert.calledWith(checkDeployStatusStub, 'deployId001', true);
   });
 
+  it('test 4b — incomplete bundle: bails with re-run guidance when js-meta.xml is absent, never deploys', async () => {
+    const { conn, deployStub } = buildConn();
+
+    // Simulates the create-then-fallback path, where createLWCBundle has
+    // filtered *.xml (including js-meta.xml) out of validFiles.
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: true,
+      validFiles: ['ccdxSample.js', 'ccdxSample.html'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js', 'lwc/ccdxSample/ccdxSample.html'],
+      fileBodyArray: ['js content', '<template></template>'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.false;
+    expect(result.message).to.include('missing ccdxSample.js-meta.xml');
+    expect(result.message).to.include('full bundle directory');
+    // Guard must short-circuit before any deploy is attempted.
+    sinon.assert.notCalled(deployStub);
+  });
+
+  it('test 4c — creation: directory deploy with no bundle Id creates the bundle (no org query)', async () => {
+    const { conn, deployStub, findStub } = buildConn();
+
+    // Mirrors the create-fallback: full bundle re-read from disk (incl. meta), empty lwcBundleId.
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: true,
+      validFiles: ['ccdxSample.js', 'ccdxSample.html', 'ccdxSample.js-meta.xml'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js', 'lwc/ccdxSample/ccdxSample.html', 'lwc/ccdxSample/ccdxSample.js-meta.xml'],
+      fileBodyArray: ['js content', '<template></template>', '<LightningComponentBundle/>'],
+      lwcBundleId: '',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.true;
+    // Directory mode must not query org resources (that branch is single-file only).
+    sinon.assert.notCalled(findStub);
+    // The deployed zip is a complete, valid bundle.
+    const [zipBuffer] = deployStub.firstCall.args;
+    const entries = new AdmZip(zipBuffer).getEntries().map(e => e.entryName);
+    expect(entries).to.include('lwc/ccdxSample/ccdxSample.js-meta.xml');
+    expect(entries).to.include('package.xml');
+  });
+
   it('test 5 — single file: fetches org resources and overlays changed file', async () => {
     const orgResources = [
       { FilePath: 'lwc/ccdxSample/ccdxSample.js', Source: 'original js' },
@@ -146,6 +218,35 @@ describe('metadataFallbackDeploy', () => {
     expect(jsEntry.getData().toString('utf8')).to.equal('updated js content');
     const htmlEntry = zip.getEntry('lwc/ccdxSample/ccdxSample.html');
     expect(htmlEntry.getData().toString('utf8')).to.equal('<template/>');
+  });
+
+  it('test 5b — single file: null org resource Source is coalesced, no Buffer TypeError', async () => {
+    const orgResources = [
+      { FilePath: 'lwc/ccdxSample/ccdxSample.js', Source: 'original js' },
+      // e.g. an empty/binary resource row that comes back with a null Source
+      { FilePath: 'lwc/ccdxSample/ccdxSample.css', Source: null as unknown as string },
+      { FilePath: 'lwc/ccdxSample/ccdxSample.js-meta.xml', Source: '<LightningComponentBundle/>' },
+    ];
+    const { conn, deployStub } = buildConn({ findResult: orgResources });
+
+    const result = await metadataFallbackDeploy({
+      conn,
+      isDirectory: false,
+      validFiles: ['ccdxSample.js'],
+      filePath: ['lwc/ccdxSample/ccdxSample.js'],
+      fileBodyArray: ['updated js content'],
+      lwcBundleId: 'bundleId001',
+      bundleName: 'ccdxSample',
+      apiVersion: '60.0',
+      timeoutMs: 5_000,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.success).to.be.true;
+    const [zipBuffer] = deployStub.firstCall.args;
+    const zip = new AdmZip(zipBuffer);
+    const cssEntry = zip.getEntry('lwc/ccdxSample/ccdxSample.css');
+    expect(cssEntry.getData().toString('utf8')).to.equal('');
   });
 
   it('test 6 — both fail: returns Metadata failure message (not original Tooling message)', async () => {


### PR DESCRIPTION
Closes #434 

## Summary

`deploy:lwc` fast-saves bundles via the Tooling API. A Tooling API Salesforce bug rejects any source importing a custom field via `@salesforce/schema/` with `FIELD_INTEGRITY_EXCEPTION`, even though the identical source deploys fine through the Metadata API.

This PR makes `deploy:lwc` automatically retry through the Metadata API when a Tooling `create`/`update` fails with that specific signature. The Tooling path is still attempted first; the fallback is transparent (spinner continues, normal success/failure shown).

## What changed

- **New `src/service/metadataDeployLwc.ts`**: `isToolingSchemaRefBug` (signature detection; genuine compile errors are not matched), `buildLwcPackageXml`, and `metadataFallbackDeploy` (zips the bundle, deploys via Metadata API, polls to completion).
- **`src/commands/deploy/lwc.ts`**: the inner `catch` now checks the predicate and delegates to the service; non-matching errors keep the original behavior.
- **`README.md`**: documents the fallback.

Directory deploys zip the local files; single-file deploys query the rest of the
bundle from the org and overlay the changed file so only the single-file changes on the org. Resource paths are validated (`lwc/…`, no `..`) before zipping.

## Testing

New unit tests in `test/commands/deploy/lwc.test.ts` cover detection, both fallback paths, both-fail messaging, timeout, path-safety, and the no-fallback regression guard.

`npm test` → **45 passing**; `npm run posttest` clean.

Additionally, you can test against this [sample project](https://github.com/jprichter/ccdx-sample) by deploying it first using `sf project deploy start` then editing `force-app/main/default/lwc/ccdxSample/ccdxSample.js` and using this plugin to save. `The save will fail against `master` and succeed against this branch.

