### PR TITLE
fix: strip trailing slash from LWC deploy path (#433)

### DIFF
--- a/src/commands/deploy/lwc.ts
+++ b/src/commands/deploy/lwc.ts
@@ -6,6 +6,7 @@ import {SobjectResult} from '../../models/sObjectResult.js';
 import {displaylog} from '../../service/displayError.js';
 import {getNameSpacePrefix} from '../../service/getNamespacePrefix.js';
 import {readBundleFiles} from '../../service/readBundleFiles.js';
+import {normalizeFilePath} from '../../service/normalizeFilePath.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 
@@ -87,7 +88,9 @@ export default class LWCDeploy extends SfCommand<any> {
       source: string;
     }
 
-    let _path = flags.filepath;
+    // Strip any trailing slash so a directory path like `lwc/ccdxSample/`
+    // still yields the bundle name `ccdxSample` rather than an empty string (issue #433).
+    let _path = normalizeFilePath(flags.filepath);
     let _fileOrDirName = _path.substring(_path.lastIndexOf('/') + 1);
     let isDirectory: boolean = false;
 

--- a/src/service/normalizeFilePath.ts
+++ b/src/service/normalizeFilePath.ts
@@ -1,0 +1,15 @@
+
+// Removes any trailing path separators so the bundle/file name can be derived
+// reliably. A path like `lwc/ccdxSample/` would otherwise yield an empty name
+// (issue #433), producing `FIELD_INTEGRITY_EXCEPTION: Invalid fullName:`.
+// A lone separator (e.g. `/`) is preserved so the path never becomes empty.
+export function normalizeFilePath(filepath: string): string {
+  if (!filepath) {
+    return filepath;
+  }
+  let normalized = filepath;
+  while (normalized.length > 1 && (normalized.endsWith('/') || normalized.endsWith('\\'))) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}

--- a/test/service/normalizeFilePath.test.ts
+++ b/test/service/normalizeFilePath.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { normalizeFilePath } from '../../src/service/normalizeFilePath.js';
+
+describe('normalizeFilePath', () => {
+
+  it('strips a single trailing slash from a directory path (issue #433)', () => {
+    expect(normalizeFilePath('force-app/main/default/lwc/ccdxSample/')).to.equal('force-app/main/default/lwc/ccdxSample');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    expect(normalizeFilePath('force-app/main/default/lwc/ccdxSample///')).to.equal('force-app/main/default/lwc/ccdxSample');
+  });
+
+  it('strips a trailing backslash (Windows path)', () => {
+    expect(normalizeFilePath('c:\\ccdx-lwc-error\\force-app\\main\\default\\lwc\\ccdxSample\\')).to.equal('c:\\ccdx-lwc-error\\force-app\\main\\default\\lwc\\ccdxSample');
+  });
+
+  it('leaves a path without a trailing slash unchanged', () => {
+    expect(normalizeFilePath('force-app/main/default/lwc/ccdxSample')).to.equal('force-app/main/default/lwc/ccdxSample');
+  });
+
+  it('leaves a file path unchanged', () => {
+    expect(normalizeFilePath('force-app/main/default/lwc/ccdxSample/ccdxSample.js')).to.equal('force-app/main/default/lwc/ccdxSample/ccdxSample.js');
+  });
+
+  it('preserves a lone separator so the path never becomes empty', () => {
+    expect(normalizeFilePath('/')).to.equal('/');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(normalizeFilePath('')).to.equal('');
+  });
+});


### PR DESCRIPTION
Closes the remaining part of #433.

## Problem

After #435 fixed the `EISDIR` error, @jprichter reported that a directory path **ending in a slash** still failed:

```
sf deploy lwc -p force-app/main/default/lwc/ccdxSample/
Saving... Failed ✖
FIELD_INTEGRITY_EXCEPTION: Invalid fullName:
```

## Root cause

`_fileOrDirName = _path.substring(_path.lastIndexOf('/') + 1)` returns an **empty string** when the path ends in `/`, so the bundle `fullName` is empty (`Invalid fullName:`) and the resource paths become `lwc//<file>`.

## Fix

New `normalizeFilePath` service strips trailing path separators (`/` and `\`) before the name is derived, while preserving a lone separator so the path never becomes empty. Applied to `flags.filepath` in `deploy:lwc`.

## Testing

- New unit tests in `test/service/normalizeFilePath.test.ts` (trailing slash, multiple slashes, Windows backslash, no-op cases, lone-separator guard).
- `npm test` → **38 passing**; `npm run posttest` clean.