### PR TITLE
1.1.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mo-dx-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mo-dx-plugin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@salesforce/core": "^8.28.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mo-dx-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Mohith Shrivastava",
   "bugs": "https://github.com/ForceProjects/mo-dx-plugin/issues",
   "dependencies": {


### PR DESCRIPTION
## Summary
Syncs the `1.1.0` version bump from local `master` to the remote.

- Bump version to `1.1.0` in `package.json` and `package-lock.json`

## Notes
This is the single commit (`332e293`) that local `master` was ahead of `origin/master` by.