### PR TITLE
chore(deps): bump @salesforce/core to ^8.31.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@salesforce/core": "^8.28.3",
+        "@salesforce/core": "^8.31.1",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "adm-zip": "^0.5.17",
         "chalk": "^4.1.2",
@@ -2814,9 +2814,9 @@
       }
     },
     "node_modules/@salesforce/core": {
-      "version": "8.28.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.28.3.tgz",
-      "integrity": "sha512-DDAeHVwDO8wUlqEGwfp8Vuu7Vp7K+hpubKu6baWkHAXiO1u7ZbQkvwCbpPz9JiYEXVUBvP11JtBQ7zOUIPShlQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.31.1.tgz",
+      "integrity": "sha512-dnBfLI0v/Ucsh/QrpYPGeo39qsvvglWMRSifx1lmAwLc9QAnL3Hhp9zUxJyX5icD9jj1uMftsAtIOGyjC2+KXA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.13",
@@ -2826,7 +2826,7 @@
         "change-case": "^4.1.2",
         "fast-levenshtein": "^3.0.0",
         "faye": "^1.4.1",
-        "form-data": "^4.0.4",
+        "form-data": "^4.0.5",
         "js2xmlparser": "^4.0.1",
         "jsonwebtoken": "9.0.3",
         "jszip": "3.10.1",
@@ -2835,7 +2835,7 @@
         "pino-abstract-transport": "^1.2.0",
         "pino-pretty": "^11.3.0",
         "proper-lockfile": "^4.1.2",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "ts-retry-promise": "^0.8.1",
         "zod": "^4.1.12"
       },
@@ -8929,9 +8929,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Mohith Shrivastava",
   "bugs": "https://github.com/ForceProjects/mo-dx-plugin/issues",
   "dependencies": {
-    "@salesforce/core": "^8.28.3",
+    "@salesforce/core": "^8.31.1",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "adm-zip": "^0.5.17",
     "chalk": "^4.1.2",


### PR DESCRIPTION
## Summary
Maintenance bump of `@salesforce/core` from `^8.28.3` → `^8.31.1` (3 minor releases of upstream bug fixes and features). The caret range lets installs resolve to the latest `8.31.x`.

## Why separate from the security PR
This is intentionally **not** a security fix. Even the latest `@salesforce/core` still declares `form-data ^4.0.5`, which is satisfied by the vulnerable `4.0.5`, so bumping core does **not** resolve any advisory. The vulnerability patches (`form-data`, `uuid`, `js-yaml`) are handled independently in #447 via `overrides`. Keeping them apart so each PR has a clean, single-purpose diff.

## Changes
- `@salesforce/core`: `^8.28.3` → `^8.31.1` (`package.json` + refreshed `package-lock.json`)

## Verification
- `npm ci` — syncs cleanly (778 packages)
- `tsc -p . --noEmit` — clean
- `npm test` — **57 passing**

> Note: `8.31.2` is the absolute latest published, but `^8.31.1` already lets CI/normal installs resolve forward to it automatically.