### PR TITLE
fix(metadata:rename): resolve -o flag collision hiding default org (#443)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,16 +228,16 @@ Rename a metadata component using the Metadata API.
 
 ```
 USAGE
-  $ sf metadata:rename -t <type> -o <oldname> -n <newname> [-u <username>] [--json]
+  $ sf metadata:rename -t <type> -d <oldname> -n <newname> [-o <username>] [--json]
 
 OPTIONS
-  -t, --metadatatype    (required) Metadata type (e.g. CustomObject, CustomField)
-  -o, --oldfullname     (required) Current API name of the component
-  -n, --newfullname     (required) New API name for the component
-  -u, --targetusername  Username or alias for the target org
+  -t, --metadatatype  (required) Metadata type (e.g. CustomObject, CustomField)
+  -d, --oldfullname   (required) Current API name of the component
+  -n, --newfullname   (required) New API name for the component
+  -o, --target-org    Username or alias for the target org; defaults to the configured default org
 
 EXAMPLES
-  $ sf metadata:rename -t CustomObject -o MyObject__c -n RenamedObject__c
+  $ sf metadata:rename -t CustomObject -d MyObject__c -n RenamedObject__c
 ```
 
 ---

--- a/src/commands/deploy/apex.ts
+++ b/src/commands/deploy/apex.ts
@@ -22,7 +22,7 @@ export default class ApexDeploy extends SfCommand<any> {
   public static description = messages.getMessage('apexDeploy');
 
   public static examples = [
-  '$ sfdx deploy:apex -p filepath'
+  '$ sf deploy:apex -p filepath'
   ];
 
   public static readonly flags = {

--- a/src/commands/deploy/aura.ts
+++ b/src/commands/deploy/aura.ts
@@ -15,7 +15,7 @@ export default class AuraDeploy extends SfCommand<any> {
   public static description = messages.getMessage('auraDeploy');
 
   public static examples = [
-  '$ sfdx deploy:aura -p filepath'
+  '$ sf deploy:aura -p filepath'
   ];
 
   public static readonly flags = {

--- a/src/commands/deploy/lwc.ts
+++ b/src/commands/deploy/lwc.ts
@@ -18,7 +18,7 @@ export default class LWCDeploy extends SfCommand<any> {
   public static description = messages.getMessage('lwcDeploy');
 
   public static examples = [
-  '$ sfdx deploy:lwc -p filepath'
+  '$ sf deploy:lwc -p filepath'
   ];
 
   public static readonly flags = {

--- a/src/commands/deploy/staticresource.ts
+++ b/src/commands/deploy/staticresource.ts
@@ -15,9 +15,9 @@ export default class StaticResourceDeploy extends SfCommand<any> {
   public static description = messages.getMessage("staticresourceDeploy");
 
   public static examples = [
-    "$ sfdx deploy:staticresource -p <filepath>",
-    "$ sfdx deploy:staticresource -p <filepath> --cachecontrol public",
-    "$ sfdx deploy:staticresource -p <filepath> --cachecontrol public --resourcefolder <name of the folder where you have single page app>"
+    "$ sf deploy:staticresource -p <filepath>",
+    "$ sf deploy:staticresource -p <filepath> --cachecontrol public",
+    "$ sf deploy:staticresource -p <filepath> --cachecontrol public --resourcefolder <name of the folder where you have single page app>"
   ];
 
   public static readonly flags = {

--- a/src/commands/deploy/trigger.ts
+++ b/src/commands/deploy/trigger.ts
@@ -24,7 +24,7 @@ export default class TriggerDeploy extends SfCommand<any> {
   public static description = messages.getMessage('triggerDeploy');
 
   public static examples = [
-  '$ sfdx deploy:trigger -p filepath'
+  '$ sf deploy:trigger -p filepath'
   ];
 
   public static readonly flags = {

--- a/src/commands/deploy/vf.ts
+++ b/src/commands/deploy/vf.ts
@@ -24,7 +24,7 @@ export default class VfDeploy extends SfCommand<any> {
   public static description = messages.getMessage('vfDeploy');
 
   public static examples = [
-  '$ sfdx deploy:vf -p filepath'
+  '$ sf deploy:vf -p filepath'
   ];
 
   public static readonly flags = {

--- a/src/commands/deploy/vfcomponent.ts
+++ b/src/commands/deploy/vfcomponent.ts
@@ -24,7 +24,7 @@ export default class ApexComponentDeploy extends SfCommand<any> {
   public static description = messages.getMessage('vfComponentDeploy');
 
   public static examples = [
-  '$ sfdx deploy:vfcomponent -p filepath'
+  '$ sf deploy:vfcomponent -p filepath'
   ];
 
   public static readonly flags = {

--- a/src/commands/metadata/rename.ts
+++ b/src/commands/metadata/rename.ts
@@ -11,8 +11,8 @@ export default class RenameMetadata extends SfCommand<any> {
   public static description = messages.getMessage('renamemetadata');
 
   public static examples = [
-    '$ sfdx metadata:rename -t <metadatatype> -n <newname> -d <oldname>',
-    '$ sfdx metadata:rename -t CustomObject -n MyCustomObject1New__c -d MyCustomObject1__c'
+    '$ sf metadata:rename -t <metadatatype> -n <newname> -d <oldname>',
+    '$ sf metadata:rename -t CustomObject -n MyCustomObject1New__c -d MyCustomObject1__c'
   ];
 
   public static readonly flags = {

--- a/src/commands/metadata/rename.ts
+++ b/src/commands/metadata/rename.ts
@@ -11,8 +11,8 @@ export default class RenameMetadata extends SfCommand<any> {
   public static description = messages.getMessage('renamemetadata');
 
   public static examples = [
-    '$ sfdx metadata:rename -t <metadatatype> -n <newname> -o <oldname>',
-    '$ sfdx metadata:rename -t CustomObject -n MyCustomObject1New__c -o MyCustomObject1__c'
+    '$ sfdx metadata:rename -t <metadatatype> -n <newname> -d <oldname>',
+    '$ sfdx metadata:rename -t CustomObject -n MyCustomObject1New__c -d MyCustomObject1__c'
   ];
 
   public static readonly flags = {
@@ -31,7 +31,7 @@ export default class RenameMetadata extends SfCommand<any> {
       description: 'new name of the metadata element'
     }),
     oldfullname: Flags.string({
-      char: 'o',
+      char: 'd',
       required: true,
       description:
         'old name of the metadata element'

--- a/src/commands/retrieve/dxsource.ts
+++ b/src/commands/retrieve/dxsource.ts
@@ -20,10 +20,10 @@ export default class DxSource extends SfCommand<any> {
   public static description = messages.getMessage('retrieveDxSource');
 
   public static examples = [
-    '$ sfdx retrieve:dxsource -n <package/changeset>',
-    '$ sfdx retrieve:dxsource -n <package/changeset> -m "true"',
-    '$ sfdx retrieve:dxsource -n <package/changeset> -p <[pathName]>',
-    '$ sfdx retrieve:dxsource -u myOrg@example.com -n <package/changeset> -p <[pathName]>'
+    '$ sf retrieve:dxsource -n <package/changeset>',
+    '$ sf retrieve:dxsource -n <package/changeset> -m "true"',
+    '$ sf retrieve:dxsource -n <package/changeset> -p <[pathName]>',
+    '$ sf retrieve:dxsource -o myOrg@example.com -n <package/changeset> -p <[pathName]>'
   ];
 
   public static readonly flags = {

--- a/src/commands/retrieve/pkgsource.ts
+++ b/src/commands/retrieve/pkgsource.ts
@@ -16,9 +16,9 @@ export default class Pkgsource extends SfCommand<any> {
   public static description = messages.getMessage('retrieveSource');
 
   public static examples = [
-    '$ sfdx retrieve:pkgsource -n <package/changeset>',
-    '$ sfdx retrieve:pkgsource -n <package/changeset> -r <relative path where source is retrieved and unzipped>',
-    '$ sfdx retrieve:pkgsource -n <package/changeset> -r /changesets/src'
+    '$ sf retrieve:pkgsource -n <package/changeset>',
+    '$ sf retrieve:pkgsource -n <package/changeset> -r <relative path where source is retrieved and unzipped>',
+    '$ sf retrieve:pkgsource -n <package/changeset> -r /changesets/src'
   ];
 
   public static readonly flags = {


### PR DESCRIPTION
## Summary
Fixes #443 — `sf metadata rename` appeared to stop detecting the default org after 1.0.0.

## Root cause
This is a **flag-character collision**, not a default-org regression. In `metadata/rename.ts`:
- `--target-org` (via `requiredOrgFlagWithDeprecations`) uses char `-o`
- `--oldfullname` *also* declared char `-o`

So `sf metadata rename -t Skill -o A -n B` routed `-o A` into `--target-org`, and the CLI then looked for an org literally named `A`:
```
Error (NamedOrgNotFoundError): No authorization information found for A.
```
It worked in 0.3.2 because the org flag was `-u` (`--targetusername`), leaving `-o` free for the old name. The ESM modernization switched to the `-o`-based org flag, silently colliding.

## Fix
- Move `--oldfullname` to char **`-d`** so `-o` maps to `--target-org` (consistent with every other command in this plugin and the `sf` CLI convention).
- With the collision gone, `--target-org` auto-detects the configured default org when omitted — restoring the pre-1.0.0 behavior the issue describes.
- Updated the in-command examples and the README usage block (the README also had stale `-u/--targetusername` docs, now corrected).

## New usage
```
sf metadata rename -t CustomObject -d MyObject__c -n RenamedObject__c
# -o / --target-org  -> org (optional; defaults to the default org)
# -d / --oldfullname -> old name
# -n / --newfullname -> new name
```

## Verification
- `tsc -p . --noEmit` — clean
- `npm test` — 57 passing
- `metadata:rename --help` now shows `-d, --oldfullname` and `-o, --target-org` ("Not required if the target-org configuration variable is already set")

## Note
`metadata:rename` was the only command with this `-o` collision — all other commands already reserve `-o` for the org flag.