### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.2.0 (2026-06-19)
+
+A maintenance release focused on security, dependency currency, and a `metadata:rename` bug fix.
+
+### Bug Fixes
+
+- **`metadata:rename` now detects the default org again ([#443](https://github.com/msrivastav13/mo-dx-plugin/issues/443)).** The `-o` short flag was claimed by both `--target-org` and `--oldfullname`, so `sf metadata rename -t Skill -o A -n B` routed `-o A` to `--target-org` and failed with `No authorization information found for A`. `--oldfullname` now uses `-d`, freeing `-o` for `--target-org` (which auto-detects the default org when omitted, as in 0.3.2).
+
+  > ⚠️ If you script `metadata:rename`, change `-o <oldname>` to `-d <oldname>`.
+
+### Security
+
+- **Patched all known dependency vulnerabilities (13 → 0).** Added `overrides` for `form-data@^4.0.6` (high), `uuid@^11.1.1`, and `js-yaml@^4.2.0`, and refreshed the lockfile to pick up fixes for `@babel/core`, `brace-expansion`, `fast-uri`, `fast-xml-builder`, `fast-xml-parser`, and `ws`.
+
+### Dependencies
+
+- Bumped `@salesforce/core` to `^8.31.1`.
+
+### Documentation
+
+- All command examples now use the modern `sf` executable instead of the deprecated `sfdx`.
+
 ## 1.0.0 (2026-04-22)
 
 This is a major release that modernizes the entire plugin infrastructure. All 10 commands work identically to before -- no command names have changed. The `--targetusername` flag has been replaced by `--target-org` (with `-o` shorthand) to align with the modern Salesforce CLI convention.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mo-dx-plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mo-dx-plugin",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@salesforce/core": "^8.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mo-dx-plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Mohith Shrivastava",
   "bugs": "https://github.com/ForceProjects/mo-dx-plugin/issues",
   "dependencies": {


### PR DESCRIPTION
## Release 1.2.0

Minor release bundling everything merged since 1.1.0.

### Included
| PR | Change | Type |
|----|--------|------|
| #447 | Patch all known dependency vulnerabilities (13 → 0) | Security |
| #448 | Bump `@salesforce/core` to `^8.31.1` | Dependencies |
| #449 | Fix `metadata:rename` `-o` flag collision (#443) + `sfdx`→`sf` in examples | Bug fix / Docs |

### Notable behavior change
`metadata:rename` `--oldfullname` moved from `-o` to `-d` so `-o` maps to `--target-org` (restoring default-org detection). Scripts using `rename ... -o <oldname>` must switch to `-d <oldname>`. Documented in CHANGELOG.

### Changes in this PR
- `package.json` / `package-lock.json`: version `1.1.0` → `1.2.0`
- `CHANGELOG.md`: new `1.2.0` entry

### Verification
- `npm ci` — clean (778 packages)
- `npm audit` — **0 vulnerabilities**
- `npm test` — **57 passing**
- `npm run prepack` — builds, manifest + readme generated
- `npm pack --dry-run` — 105 files, 34.8 kB tarball (bin, lib, messages, manifest)

### Post-merge publish steps (manual — owner)
After merging this PR:
```
git checkout master && git pull
git tag v1.2.0 && git push origin v1.2.0
npm publish
```